### PR TITLE
Prevent caching interaction map by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yunta"
-version = "0.0.3"
+version = "0.0.4"
 authors = [
   { name="Eachan Johnson", email="eachan.johnson@crick.ac.uk" },
 ]

--- a/yunta/interaction_utils.py
+++ b/yunta/interaction_utils.py
@@ -16,6 +16,14 @@ from tqdm.auto import tqdm
 _INTERACTION_FILE_LOADED: bool = False
 ORGANISM_INTERACTIONS: dict = {}
 TEST_MODE: str = str(os.environ.get("YUNTA_TEST", "0"))
+CACHE_PATH: str = str(os.environ.get(
+    "YUNTA_CACHE", 
+    os.path.join(
+        os.path.realpath(os.path.expanduser("~")),
+        ".cache",
+        "yunta",
+    ),
+))
 
 _data_root = os.path.join(
     os.path.dirname(__file__), 
@@ -26,11 +34,11 @@ _data_csv_path = os.path.join(
     "20250409_hpi.csv",
 )
 _data_json_path = os.path.join(
-    _data_root,
+    CACHE_PATH,
     "interactions.json.gz",
 )
 _name2ncbi_path = os.path.join(
-    _data_root,
+    CACHE_PATH,
     "name-to-ncbi.json",
 )
 
@@ -121,9 +129,9 @@ def _create_data_json(
     return None
 
 
-def organism_interactions() -> Dict[str, List[str]]:
+def organism_interactions(cache: bool = False) -> Dict[str, List[str]]:
 
-    test_mode = TEST_MODE == "1"
+    test_mode = (TEST_MODE == "1") or not cache
 
     if test_mode:
         print_err("Building organism interaction lookup table and loading into memory...", flush=True)
@@ -136,6 +144,8 @@ def organism_interactions() -> Dict[str, List[str]]:
             )
         )
     else:
+        if not os.path.exists(CACHE_PATH):
+            os.makedirs(CACHE_PATH)
         if not os.path.exists(_data_json_path):
             print_err("Organism interaction lookup table not yet built; building...", flush=True)
             _create_data_json(_data_csv_path, _data_json_path, _name2ncbi_path)

--- a/yunta/interaction_utils.py
+++ b/yunta/interaction_utils.py
@@ -24,6 +24,7 @@ CACHE_PATH: str = str(os.environ.get(
         "yunta",
     ),
 ))
+USE_CACHE: str = str(os.environ.get("YUNTA_USE_CACHE", "False"))
 
 _data_root = os.path.join(
     os.path.dirname(__file__), 
@@ -127,6 +128,7 @@ def organism_interactions(
     use_cache: bool = False
 ) -> Dict[str, List[str]]:
 
+    use_cache = use_cache or (USE_CACHE == "True")
     test_mode = (TEST_MODE == "1") or not use_cache
     _data_json_path, _name2ncbi_path = (
         os.path.join(cache, filename) for filename in ("interactions.json.gz", "name-to-ncbi.json")

--- a/yunta/interaction_utils.py
+++ b/yunta/interaction_utils.py
@@ -124,7 +124,7 @@ def _create_data_json(
 
 def organism_interactions(
     cache: Optional[str] = CACHE_PATH, 
-    use_cache: bool = True
+    use_cache: bool = False
 ) -> Dict[str, List[str]]:
 
     test_mode = (TEST_MODE == "1") or not use_cache

--- a/yunta/interaction_utils.py
+++ b/yunta/interaction_utils.py
@@ -93,13 +93,14 @@ def _create_data_json(
             name_to_ncbi[getattr(row, name_col)].add(f"{prefix}{int(getattr(row, ncbi_col))}")
     # make sure NCBI Taxon IDs aren't overly specific
     # interaction_map_expanded = deepcopy(interaction_map)
-    with open(name2ncbi_path, "w") as f:
-        json.dump( 
-            {key: sorted(val) for key, val in name_to_ncbi.items()}, 
-            f, 
-            sort_keys=True, 
-            indent=4,
-        )
+    if not test_mode:
+        with open(name2ncbi_path, "w") as f:
+            json.dump( 
+                {key: sorted(val) for key, val in name_to_ncbi.items()}, 
+                f, 
+                sort_keys=True, 
+                indent=4,
+            )
     additional = defaultdict(set)
     for key, value in tqdm(interaction_map["name"].items()):
         vals_to_add = set()

--- a/yunta/interaction_utils.py
+++ b/yunta/interaction_utils.py
@@ -124,7 +124,7 @@ def _create_data_json(
 
 
 def organism_interactions(
-    cache: Optional[str] = CACHE_PATH, 
+    cache: str = CACHE_PATH, 
     use_cache: bool = False
 ) -> Dict[str, List[str]]:
 

--- a/yunta/interaction_utils.py
+++ b/yunta/interaction_utils.py
@@ -33,14 +33,6 @@ _data_csv_path = os.path.join(
     _data_root,
     "20250409_hpi.csv",
 )
-_data_json_path = os.path.join(
-    CACHE_PATH,
-    "interactions.json.gz",
-)
-_name2ncbi_path = os.path.join(
-    CACHE_PATH,
-    "name-to-ncbi.json",
-)
 
 
 def _name_normalizer(x: Iterable[str]):
@@ -130,9 +122,15 @@ def _create_data_json(
     return None
 
 
-def organism_interactions(cache: bool = False) -> Dict[str, List[str]]:
+def organism_interactions(
+    cache: Optional[str] = CACHE_PATH, 
+    use_cache: bool = True
+) -> Dict[str, List[str]]:
 
-    test_mode = (TEST_MODE == "1") or not cache
+    test_mode = (TEST_MODE == "1") or not use_cache
+    _data_json_path, _name2ncbi_path = (
+        os.path.join(cache, filename) for filename in ("interactions.json.gz", "name-to-ncbi.json")
+    )
 
     if test_mode:
         print_err("Building organism interaction lookup table and loading into memory...", flush=True)


### PR DESCRIPTION
One-time caching of the interaction map takes a lot of time and compression IO overhead, which is unfriendly to some applications like building containers. 

This PR moves the default interaction cache to `~/.cache/yunta` and turns off caching by default. It can be turned back on by setting the environment variable `YUNTA_USE_CACHE=True`. The cache path can be set with `YUNTA_CACHE=/path/to/cache`.