### PR TITLE
Fix fallback bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yunta"
-version = "0.0.6.post1"
+version = "0.0.6.post2"
 authors = [
   { name="Eachan Johnson", email="eachan.johnson@crick.ac.uk" },
 ]

--- a/test/scripts/test.sh
+++ b/test/scripts/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euox pipefail
+set -eox pipefail
 
 INPUT_INTER1=test/inputs/Q38361_D29_integrase.a3m
 INPUT_INTER2=test/inputs/P9WGF1_Mtb_Mmr.a3m
@@ -57,7 +57,7 @@ then
     exit 1
 fi
 
-if [ -z $1 ]
+if [ -z "$1" ]
 then
     yunta rf2t-single $INPUT1 -2 $INPUT2 \
         -o test/outputs/rf2t-single.tsv \

--- a/yunta/interaction_utils.py
+++ b/yunta/interaction_utils.py
@@ -160,6 +160,7 @@ def organism_interactions(
                             test_mode=test_mode,
                         )
                     )
+                return ORGANISM_INTERACTIONS
         if not os.path.exists(_data_json_path):
             print_err("Organism interaction lookup table not yet built; building...", flush=True)
             _create_data_json(_data_csv_path, _data_json_path, _name2ncbi_path)


### PR DESCRIPTION
On non-writable filesystems (like Singularity containers), the OSError wasn't caught correctly. The `organism_interactions` function should now return before trying to write again.