### PR TITLE
Guard empty paired MSAs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yunta"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
   { name="Eachan Johnson", email="eachan.johnson@crick.ac.uk" },
 ]

--- a/yunta/interaction_utils.py
+++ b/yunta/interaction_utils.py
@@ -31,7 +31,7 @@ _data_root = os.path.join(
 )
 _data_csv_path = os.path.join(
     _data_root,
-    "20250409_hpi.csv",
+    "20260516_hpi.csv",
 )
 
 

--- a/yunta/interactions/runner.py
+++ b/yunta/interactions/runner.py
@@ -26,16 +26,22 @@ def _pair_msas(
     interaction_map: Optional[Union[str, Mapping[str, Iterable[str]]]] = None,
     enforce_ref_match: bool = False
 ) -> PairedMSA:
-    return (
-        PairedMSA.from_msa(
+    try:
+        paired_msa = PairedMSA.from_msa(
             msa1, 
             msa2, 
             blocked=blocked, 
             interaction_map=interaction_map,
             enforce_ref_match=enforce_ref_match,
         )
-        .filter_by_gap_fraction(max_gap_fraction)
-    )
+    except AttributeError as e:  # no pairs!
+        print_err(f"[WARN] Skipping pair,", e)
+        return None
+    else:
+        return (
+            paired_msa
+            .filter_by_gap_fraction(max_gap_fraction)
+        )
 
 
 def _calculate_interaction_blocks(
@@ -173,6 +179,8 @@ class Runner(ABC):
             interaction_map=interaction_map,
             enforce_ref_match=enforce_ref_match,
         )
+        if paired_msa is None:  # failure
+            return None, None, None
         print_err("[INFO] Generated", paired_msa)
         neff = paired_msa.neff()
 
@@ -185,7 +193,7 @@ class Runner(ABC):
             chunksize=chunksize,
             use_sequences=self.use_sequences,
             use_id=self.use_id,
-            **kwargs
+            **kwargs,
         )
         result_interaction = results[:paired_msa.chain_a_length, paired_msa.chain_a_length:]
         scores = score_contact_map(result_interaction)

--- a/yunta/screening.py
+++ b/yunta/screening.py
@@ -46,15 +46,18 @@ def _screen_one_vs_many(
     for msa2 in tqdm(msa_file2):
         if msa2 is not None:
             msa2 = MSA.from_file(msa2)
-        results.append(
-            runner().run(
-                msa1=msa1,
-                msa2=msa2,
-                max_gap_fraction=max_gap_fraction, 
-                interaction_map=interaction_map,
-                **kwargs,
-            )
+        result = runner().run(
+            msa1=msa1,
+            msa2=msa2,
+            max_gap_fraction=max_gap_fraction, 
+            interaction_map=interaction_map,
+            **kwargs,
         )
+        if result[0] is not None:
+            results.append(result)
+        else:
+            print_err(f"[WARN] Failed calculation for {msa1}, {msa2}. Continuing.")
+            continue
     return results
 
 

--- a/yunta/structs/msa.py
+++ b/yunta/structs/msa.py
@@ -579,7 +579,10 @@ class PairedMSA(MSA):
             enforce_ref_match=enforce_ref_match,
             **kwargs
         )
-        return cls(lines=msa_lines, chain_a_length=chain_a_length)
+        if len(msa_lines) > 0:
+            return cls(lines=msa_lines, chain_a_length=chain_a_length)
+        else:
+            raise AttributeError(f"Pairing {msa1} and {msa2} resulted in no pairs.")
 
     @classmethod
     def from_file(


### PR DESCRIPTION
Caused an error common in interspecies MSAs, if no pairs were found. Could happen in shallow or poorly annotated MSAs.